### PR TITLE
fix(cmake) Use + separated list as configuration variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ string(REGEX MATCH "VERSION = ([0-9]*.[0-9]*.[0-9]*)" _ ${PROJECT_PROPERTIES})
 set(PROJECT_VERSION ${CMAKE_MATCH_1})
 project(libethercat VERSION ${PROJECT_VERSION})
 
-set(ECAT_DEVICE "sock_raw" CACHE STRING "EtherCAT device layer as `;` separated list")
+set(ECAT_DEVICE "sock_raw" CACHE STRING "EtherCAT device layer as `+` separated list")
+string(REPLACE "+" ";" ECAT_DEVICE ${ECAT_DEVICE})
 
 include(CheckIncludeFiles)
 include(CheckSymbolExists)

--- a/README.md
+++ b/README.md
@@ -64,14 +64,23 @@ This will build and install a static as well as a dynamic library. For use in ot
 
 ### CMake
 
+Steps to build:
 ```bash
 mkdir build
 cd build
 # Please change the path to the install dir. If you chose a global install you can omit the CMAKE_PREFIX_PATH option
-# You can specify which EtherCAT devices should be included into the build with -DECAT_DEVICE="sock_raw;sock_raw_mmaped;..."
-cmake .. -DCMAKE_PREFIX_PATH=<installdir of libosal> -DECAT_DEVICE="sock_raw;sock_raw_mmaped"
+# You can specify which EtherCAT devices should be included into the build with -DECAT_DEVICE="sock_raw+sock_raw_mmaped+..."
+cmake .. -DCMAKE_PREFIX_PATH=<installdir of libosal> -DECAT_DEVICE="sock_raw+sock_raw_mmaped"
 cmake --build . 
 ```
+
+#### Configuration parameters
+
+| Parameter         | Default  | Description                                                                                               |
+|-------------------|----------|-----------------------------------------------------------------------------------------------------------|
+| CMAKE_PREFIX_PATH |          | Install directory of the libosal                                                                          |
+| ECAT_DEVICE       | sock_raw | List of EtherCAT devices as `+` separated list. Possible values: sock_raw+sock_raw_mmaped+file+pikeos+bpf |
+| BUILD_SHARED_LIBS | OFF      | Flag to build shared libraries instead of static ones.                                                    |
 
 ## Tools
 


### PR DESCRIPTION
Using ; as separator breaks the configuration in ExternalProject_Add

I also added a list with the CMake configuration variables