### PR TITLE
feat: Support the configuration of slaves to use only dc sync1

### DIFF
--- a/include/libethercat/dc.h
+++ b/include/libethercat/dc.h
@@ -60,6 +60,10 @@
 #define EC_REG_DCSYNCACT__SYNC_OUT_UNIT_NEAR_FUTURE_CONFIG      ( 0x40u )
 #define EC_REG_DCSYNCACT__SYNC_OUT_UNIT_DEBUG_PULSE             ( 0x80u )
 
+#define EC_DC_ACTIVATION_REG_SYNC0                              ( 0x3 )
+#define EC_DC_ACTIVATION_REG_SYNC1                              ( 0x5 )
+#define EC_DC_ACTIVATION_REG_SYNC01                             ( 0x7 )
+
 typedef struct ec_dc_info_slave {
     int use_dc;                     //!< \brief flag, whether to use dc
     int next;                       //!< \brief marker for next dc slave
@@ -73,7 +77,7 @@ typedef struct ec_dc_info_slave {
     osal_int32_t t_delay_slave;
     osal_int32_t t_delay_parent_previous;
                  
-    int type;                       //!< \brief dc type, 0 = sync0, 1 = sync01
+    int activation_reg;             //!< \brief DC Sync Activation Register (0x981). 0x3 = Sync0, 0x5 = Sync1, 0x7 = Sync01
     osal_uint32_t cycle_time_0;     //!< \brief cycle time of sync 0 [ns]
     osal_uint32_t cycle_time_1;     //!< \brief cycle time of sync 1 [ns]
     osal_int32_t cycle_shift;       //!< \brief cycle shift time [ns]

--- a/include/libethercat/slave.h
+++ b/include/libethercat/slave.h
@@ -527,7 +527,7 @@ void ec_slave_add_init_cmd(ec_t *pec, osal_uint16_t slave, ec_init_cmd_t *cmd);
  *                          the physical order of the ethercat slaves 
  *                          (usually the n'th slave attached).
  * \param[in] use_dc        Whether to en-/disable dc on slave.
- * \param[in] type          DC type, 0 = sync0, 1 = sync01.
+ * \param[in] type          DC type, 0 = sync0, 1 = sync01, 2 = sync1.
  * \param[in] cycle_time_0  Cycle time of sync 0 [ns].
  * \param[in] cycle_time_1  Cycle time of sync 1 [ns].
  * \param[in] cycle_shift   Cycle shift time [ns].

--- a/include/libethercat/slave.h
+++ b/include/libethercat/slave.h
@@ -521,16 +521,20 @@ void ec_slave_add_init_cmd(ec_t *pec, osal_uint16_t slave, ec_init_cmd_t *cmd);
 
 //! Set Distributed Clocks config to slave
 /*! 
- * \param[in] pec           Pointer to ethercat master structure, 
- *                          which you got from \link ec_open \endlink.
- * \param[in] slave         Number of ethercat slave. this depends on 
- *                          the physical order of the ethercat slaves 
- *                          (usually the n'th slave attached).
- * \param[in] use_dc        Whether to en-/disable dc on slave.
- * \param[in] type          DC type, 0 = sync0, 1 = sync01, 2 = sync1.
- * \param[in] cycle_time_0  Cycle time of sync 0 [ns].
- * \param[in] cycle_time_1  Cycle time of sync 1 [ns].
- * \param[in] cycle_shift   Cycle shift time [ns].
+ * \param[in] pec            Pointer to ethercat master structure, 
+ *                           which you got from \link ec_open \endlink.
+ * \param[in] slave          Number of ethercat slave. this depends on 
+ *                           the physical order of the ethercat slaves 
+ *                           (usually the n'th slave attached).
+ * \param[in] use_dc         Whether to en-/disable dc on slave.
+ * \param[in] activation_reg DC Sync Activation Register (0x981). Sets
+ *                           the type of DC sync:
+ *                           * 0x3 = Sync0
+ *                           * 0x5 = Sync1
+ *                           * 0x7 = Sync01
+ * \param[in] cycle_time_0   Cycle time of sync 0 [ns].
+ * \param[in] cycle_time_1   Cycle time of sync 1 [ns].
+ * \param[in] cycle_shift    Cycle shift time [ns].
  */
 void ec_slave_set_dc_config(struct ec *pec, osal_uint16_t slave, 
         int use_dc, int type, osal_uint32_t cycle_time_0, 

--- a/src/coe_master.c
+++ b/src/coe_master.c
@@ -309,7 +309,7 @@ static int callback_master_0x3nnn(ec_t *pec, const ec_coe_object_t *coe_obj, osa
     } else if (sub_index == 8u) {
         BUF_PUT(osal_uint32_t, &pec->slaves[slave].dc.receive_times[3]);
     } else if (sub_index == 9u) {
-        BUF_PUT(osal_uint8_t, &pec->slaves[slave].dc.type);
+        BUF_PUT(osal_uint8_t, &pec->slaves[slave].dc.activation_reg);
     } else if (sub_index == 10u) {
         BUF_PUT(osal_uint32_t, &pec->slaves[slave].dc.cycle_time_0);
     } else if (sub_index == 11u) {

--- a/src/slave.c
+++ b/src/slave.c
@@ -1051,8 +1051,16 @@ int ec_slave_state_transition(ec_t *pec, osal_uint16_t slave, ec_state_t state) 
                     if (slv->dc.cycle_time_0 == 0u) {
                         slv->dc.cycle_time_0 = pec->main_cycle_interval; 
                     }
+                    if (slv->dc.type == 2) {
+                         ec_log(10, get_transition_string(transition), 
+                                "slave %2d: configuring dc sync 1, "
+                                "cycle_times %d/%d, cycle_shift %d\n", 
+                                slave, slv->dc.cycle_time_0, 
+                                slv->dc.cycle_time_1, slv->dc.cycle_shift);
 
-                    if (slv->dc.type == 1) {
+                        ec_dc_sync(pec, slave, 5, slv->dc.cycle_time_0, 
+                                slv->dc.cycle_time_1, slv->dc.cycle_shift); 
+                    } else if (slv->dc.type == 1) {
                         if (slv->dc.cycle_time_1 == 0u) {
                             slv->dc.cycle_time_1 = pec->main_cycle_interval; 
                         }

--- a/tools/example_with_dc/example_with_dc.c
+++ b/tools/example_with_dc/example_with_dc.c
@@ -363,7 +363,7 @@ int main(int argc, char **argv) {
     // configure slave settings.
     for (int i = 0; i < ec.slave_cnt; ++i) {
         ec.slaves[i].assigned_pd_group = 0;
-        ec_slave_set_dc_config(&ec, i, 1, 0, cycle_rate, 0, 0);
+        ec_slave_set_dc_config(&ec, i, 1, EC_DC_ACTIVATION_REG_SYNC0, cycle_rate, 0, 0);
     }
 
     cyclic_task_running = OSAL_TRUE;


### PR DESCRIPTION
Our problems with #15 come from a wrong DC configuration.
TwinCAT only uses the SYNC1 signal. If we use the same configuration, the slave can go to OP.

I don't know how to read this from the ESI, but it works.
```xml
<Dc>
	<OpMode>
		<Name>DcSync500us</Name>
		<Desc>DC-Synchron (Sync0Shift 500us)</Desc>
		<AssignActivate>#x0500</AssignActivate>
		<CycleTimeSync0 Factor="1">0</CycleTimeSync0>
		<ShiftTimeSync0>500000</ShiftTimeSync0>
	</OpMode>
	<OpMode>
		<Name>DcSync250us</Name>
		<Desc>DC-Synchron (Sync0Shift 250us)</Desc>
		<AssignActivate>#x0500</AssignActivate>
		<CycleTimeSync0 Factor="1">0</CycleTimeSync0>
		<ShiftTimeSync0>250000</ShiftTimeSync0>
	</OpMode>
	<OpMode>
		<Name>DcSync1000us</Name>
		<Desc>DC-Synchron (Sync0Shift 1000us)</Desc>
		<AssignActivate>#x0500</AssignActivate>
		<CycleTimeSync0 Factor="1">0</CycleTimeSync0>
		<ShiftTimeSync0>1000000</ShiftTimeSync0>
	</OpMode>
	<OpMode>
		<Name>FreeRun</Name>
		<Desc>Free Run (no synchronization)</Desc>
		<AssignActivate>#x0000</AssignActivate>
	</OpMode>
</Dc>
```