### PR TITLE
Enable custom rtc clock source

### DIFF
--- a/include/libethercat/ec.h
+++ b/include/libethercat/ec.h
@@ -395,6 +395,17 @@ int ec_send_process_data(ec_t *pec);
  */
 int ec_send_distributed_clocks_sync(ec_t *pec);
 
+//! \brief Send distributed clock sync datagram
+/*!
+ * \param pec          Pointer to ethercat master structure, 
+ *                     which you got from \link ec_open \endlink.
+ * \param act_rtc_time Current real-time clock value. If 0, the time of 
+ *                     osal_timer_gettime_nsec() will be used. Otherwise
+ *                     the supplied time is used.
+ * \return 0 on success
+ */
+int ec_send_distributed_clocks_sync_with_rtc(ec_t *pec, osal_uint64_t act_rtc_time);
+
 //! \brief Send broadcast read to ec state.
 /*!
  * \param[in] pec           Pointer to ethercat master structure, 

--- a/src/ec.c
+++ b/src/ec.c
@@ -1840,10 +1840,13 @@ static void cb_distributed_clocks(struct ec *pec, pool_entry_t *p_entry, ec_data
 
 //! send distributed clock sync datagram
 /*!
- * \param pec ethercat master pointer
+ * \param pec          ethercat master pointer
+ * \param act_rtc_time Current real-time clock value. If 0, the time of 
+ *                     osal_timer_gettime_nsec() will be used. Otherwise
+ *                     the supplied time is used.
  * \return 0 on success
  */
-int ec_send_distributed_clocks_sync(ec_t *pec) {
+int ec_send_distributed_clocks_sync_intern(ec_t *pec, osal_uint64_t act_rtc_time) {
     assert(pec != NULL);
 
     int ret = EC_OK;
@@ -1891,7 +1894,9 @@ int ec_send_distributed_clocks_sync(ec_t *pec) {
                 p_dg->adr = ((osal_uint32_t)EC_REG_DCSYSTIME << 16u) | pec->dc.master_address;
             }
 
-            osal_uint64_t act_rtc_time = osal_timer_gettime_nsec();
+            if (act_rtc_time == 0){
+                act_rtc_time = osal_timer_gettime_nsec();
+            } 
 
             if (pec->dc.mode == dc_mode_ref_clock) {
                 if (pec->main_cycle_interval > 0) {
@@ -1915,6 +1920,27 @@ int ec_send_distributed_clocks_sync(ec_t *pec) {
     osal_mutex_unlock(&pec->dc.cdg.lock);
       
     return ret;
+}
+
+//! send distributed clock sync datagram
+/*!
+ * \param pec ethercat master pointer
+ * \return 0 on success
+ */
+int ec_send_distributed_clocks_sync(ec_t *pec) {
+    return ec_send_distributed_clocks_sync_intern(pec,0);
+}
+
+//! send distributed clock sync datagram
+/*!
+ * \param pec          ethercat master pointer
+ * \param act_rtc_time Current real-time clock value. If 0, the time of 
+ *                     osal_timer_gettime_nsec() will be used. Otherwise
+ *                     the supplied time is used.
+ * \return 0 on success
+ */
+int ec_send_distributed_clocks_sync_with_rtc(ec_t *pec, osal_uint64_t act_rtc_time) {
+    return ec_send_distributed_clocks_sync_intern(pec,act_rtc_time);
 }
 
 //! local callack for syncronous read/write

--- a/src/ec.c
+++ b/src/ec.c
@@ -74,6 +74,7 @@
 
 // forward declaration
 static void default_log_func(ec_t *pec, int lvl, const osal_char_t *format, ...) __attribute__ ((format (printf, 3, 4)));
+static int ec_send_distributed_clocks_sync_intern(ec_t *pec, osal_uint64_t act_rtc_time);
 
 //! calculate signed difference of 64-bit unsigned int's
 /*!
@@ -1894,10 +1895,6 @@ int ec_send_distributed_clocks_sync_intern(ec_t *pec, osal_uint64_t act_rtc_time
                 p_dg->adr = ((osal_uint32_t)EC_REG_DCSYSTIME << 16u) | pec->dc.master_address;
             }
 
-            if (act_rtc_time == 0){
-                act_rtc_time = osal_timer_gettime_nsec();
-            } 
-
             if (pec->dc.mode == dc_mode_ref_clock) {
                 if (pec->main_cycle_interval > 0) {
                     pec->dc.rtc_time += (osal_uint64_t)(pec->main_cycle_interval);
@@ -1928,7 +1925,7 @@ int ec_send_distributed_clocks_sync_intern(ec_t *pec, osal_uint64_t act_rtc_time
  * \return 0 on success
  */
 int ec_send_distributed_clocks_sync(ec_t *pec) {
-    return ec_send_distributed_clocks_sync_intern(pec,0);
+    return ec_send_distributed_clocks_sync_intern(pec, osal_timer_gettime_nsec());
 }
 
 //! send distributed clock sync datagram


### PR DESCRIPTION
Solves #23 

The question for me is whether the following line also needs to be adapted to the custom CLOCK_SOURCE.
https://github.com/robert-burger/libethercat/blob/9108db144f028f763203957c595d9b39bc04505e/src/dc.c#L354

The packet latency in
https://github.com/robert-burger/libethercat/blob/9108db144f028f763203957c595d9b39bc04505e/src/dc.c#L100-L108
also uses `osal_timer_gettime_nsec()`. In libosal for POSIX, CLOCK_REALTIME is currently used, which I think is not optimal, because it can be changed by NTP ([see here](https://man7.org/linux/man-pages/man3/clock_gettime.3.html)). So, at least for Linux CLOCK_MONOTONIC is better.

For measuring packet latency it doesn't matter which time reference is used, but for DC sync it is important if you want to synchronize the master rtc to an external clock, e.g. via PTP. In this case, you would prefer CLOCK_TAI.